### PR TITLE
changed default to generate LOD because 99% of the time it's the best.

### DIFF
--- a/buildOptions.txt
+++ b/buildOptions.txt
@@ -21,6 +21,6 @@
   + Tournament2
 
 % Archivist
-  * Default
-  + LODwAP
+  + Default
+  * LODwAP
   + SSwD


### PR DESCRIPTION
This is a modification of which Archivist is the default. I just discovered that the default archivist doesn't allow Line of Descent and it should because usually not much else matters. This will help people get started off on the right foot. Perhaps a more permanent solution is to rename the archivists so none are named "default" since that's not descriptive.