### PR TITLE
Added synctatic sugar for the whole setting up, declaring and initial…

### DIFF
--- a/Utilities/Parameters.h
+++ b/Utilities/Parameters.h
@@ -11,6 +11,21 @@
 #ifndef __MABE__Parameters__
 #define __MABE__Parameters__
 
+
+
+/********* 				Synctatic sugar for Paramter Link registration  ********/
+#define _DECL_PARAM_(Type,Name) Type Name; static shared_ptr<ParameterLink<Type>> Name##PL;
+#define _REG_PARAM_(World,Type,Name,DefaultVal,Message) shared_ptr<ParameterLink<Type>> World::Name##PL = Parameters::register_parameter( "WORLD_"#World"-"#Name , DefaultVal , Message );
+#define _INIT_PARAM_(World,Type,Name) Name = (PT == nullptr) ? Name##PL->lookup(): PT->lookup##Type( "WORLD_"#World"-"#Name );
+/*Then in ExampleWorld.h  what used to be int exampleVariable; static shared_ptr<ParameterLink<int>> exampleVariablePL; now becomes simply _DECL_PARAM_(int,exampleVariable)
+And in ExampleWorld.cpp, instead of globally registering the parameter as shared_ptr<ParameterLink<int>> ExampleWorld::exampleVariablePL = Parameters::register_parameter("WORLD_ExampleWorld-exampleVariable",  42, "Example messagge for this variable"); we now simply say _REG_PARAM_(ExampleWorld, int, exampleVariable, 42, ""Example messagge for this variable")
+And in the ExampleWorld constructor, instead of looking it up like exampleVariable = (PT == nullptr) ? exampleVariablePL->lookup(): PT->lookupInt("WORLD_ExampleWorld-exampleVariable"); we can say _INIT_PARAM_(ExampleWorldWorld, Int, exameVariable)
+*/
+/********* 	End of 			Synctatic sugar for Paramter Link registration  ********/
+
+
+
+
 #include "Utilities.h"
 //#include "AssertWithMessage.h"
 #include <type_traits>


### PR DESCRIPTION
…ising Parameters Link.

The Parameters system makes writing new Worlds slightly tedious and error prone. Original plan was to have a small script that parsed World source and header files to make sure they were consistent (using some textual tags embedded in the header files. But while implementing it, i realized that we could make the parameter stuff more opaque and avoid errors there. The solution is to use Macros ( I know, but it works :P).

Added the following to Utilities/Parameters.h
#define DECL_PARAM_(Type,Name) Type Name; static shared_ptr<ParameterLink<Type>> Name##PL; #define _REG_PARAM_(World,Type,Name,DefaultVal,Message) shared_ptr<ParameterLink<Type>> World::Name##PL = Parameters::register_parameter( "WORLD"#World"-"#Name , DefaultVal , Message );#define INIT_PARAM_(World,Type,Name) Name = (PT == nullptr) ? Name##PL->lookup(): PT->lookup##Type( "WORLD"#World"-"#Name );'

Then in ExampleWorld.cpp  what used to be int exampleVariable; static shared_ptr<ParameterLink<int>> exampleVariablePL; now becomes simply _DECL_PARAM_(int,exampleVariable)

And in ExampleWorld.cpp, instead of globally registering the parameter as shared_ptr<ParameterLink<int>> ExampleWorld::exampleVariablePL = Parameters::register_parameter("WORLD_ExampleWorld-exampleVariable",  42, "Example messagge for this variable"); we now simply say _REG_PARAM_(ExampleWorld, int, exampleVariable, 42, ""Example messagge for this variable")

And in the ExampleWorld constructor, instead of looking it up like exampleVariable = (PT == nullptr) ? exampleVariablePL->lookup(): PT->lookupInt("WORLD_ExampleWorld-exampleVariable"); we can say _INIT_PARAM_(ExampleWorldWorld, Int, exameVariable)

Less typing involved, and thee programmer doesn't need to bother with the named reference to the PT, so less potential for errors there.

The code didn't show up properly earlier, but all that needs to be added is the following to AbstractWorld.h

#define _DECL_PARAM_(Type,Name) Type Name; static shared_ptr<ParameterLink<Type>> Name##PL; 

_#define _REG_PARAM_(World,Type,Name,DefaultVal,Message) shared_ptr<ParameterLink<Type>> World::Name##PL = Parameters::register_parameter( "WORLD_"#World"-"#Name , DefaultVal , Message );

#define _INIT_PARAM_(World,Type,Name) Name = (PT == nullptr) ? Name##PL->lookup(): PT->lookup##Type( "WORLD_"#World"-"#Name );

This could maybe extended to other modules, but if users are mucking about with Parameter's in other modules, they can figure it out.
What do y'all think?