### PR TITLE
Hotfixes

### DIFF
--- a/World/IPDWorld/IPDWorld.cpp
+++ b/World/IPDWorld/IPDWorld.cpp
@@ -109,7 +109,7 @@ IPDWorld::IPDWorld(shared_ptr<ParametersTable> _PT) :
 	popFileColumns.push_back("DC");
 	if (playsVsFixedStrategies > 0) {
 		for (auto s : fixedStrategies) {
-			popFileColumns.push_back("score_vs_" + s);
+			popFileColumns.push_back("score-vs-" + s); // don't use underscores unless they are for specifying _VAR _AVE etc.
 		}
 	}
 }
@@ -238,11 +238,11 @@ void IPDWorld::evaluate(map<string, shared_ptr<Group>>& groups, int analyse, int
 		for (int fixedOrgsCount = 0; fixedOrgsCount < (int)fixedOrgs.size(); fixedOrgsCount++) {
 			//cout << "fixedOrgsCount:" << fixedOrgsCount << "  fixedOrgs.size()" << fixedOrgs.size() << endl;
 			for (int j = 0; j < playsVsFixedStrategies; j++) {
-				//cout << "score_vs_" + fixedStrategies[fixedOrgsCount] << endl;
+				//cout << "score-vs-" + fixedStrategies[fixedOrgsCount] << endl;
 				//cout << "j:" << j << "  playsVsFixedStrategies:" << playsVsFixedStrategies << endl;
 				pair<double,double> scores = runDuel(group->population[i], fixedOrgs[fixedOrgsCount], analyse, visualize, debug);
 				//cout << scores.first << "  " << scores.second << endl;
-				group->population[i]->dataMap.Append("score_vs_" + fixedStrategies[fixedOrgsCount], scores.first);
+				group->population[i]->dataMap.Append("score-vs-" + fixedStrategies[fixedOrgsCount], scores.first);
 				
 				////runDuel(group->population[i], fixedOrgs[fixedOrgsCount], analyse, visualize, debug);
 			}

--- a/World/NumeralClassifierWorld/NumeralClassifierWorld.cpp
+++ b/World/NumeralClassifierWorld/NumeralClassifierWorld.cpp
@@ -115,8 +115,8 @@ NumeralClassifierWorld::NumeralClassifierWorld(shared_ptr<ParametersTable> _PT) 
 	popFileColumns.push_back("score");
 
 	for (int i = 0; i < 10; i++) {
-		popFileColumns.push_back(to_string(i) + "_correct");
-		popFileColumns.push_back(to_string(i) + "_incorrect");
+		popFileColumns.push_back(to_string(i) + "-correct");
+		popFileColumns.push_back(to_string(i) + "-incorrect");
 	}
 	popFileColumns.push_back("totalCorrect");
 	popFileColumns.push_back("totalIncorrect");
@@ -357,12 +357,12 @@ void NumeralClassifierWorld::evaluateSolo(shared_ptr<Organism> org, int analyse,
 		total_correct += correct[i];
 		total_incorrect += incorrect[i];
 
-		temp_name = to_string(i) + "_correct";  // make food names i.e. food1, food2, etc.
+		temp_name = to_string(i) + "-correct";  // make food names i.e. food1, food2, etc.
 		(counts[i] > 0) ? val = (double) correct[i] / (double) counts[i] : val = 0;
 		org->dataMap.Append(temp_name, val);
 		org->dataMap.setOutputBehavior(temp_name, DataMap::AVE);
 
-		temp_name = to_string(i) + "_incorrect";  // make food names i.e. food1, food2, etc.
+		temp_name = to_string(i) + "-incorrect";  // make food names i.e. food1, food2, etc.
 		(counts[i] < testsPreWorldEval) ? val = (double) incorrect[i] / ((double) testsPreWorldEval - counts[i]) : val = 0;
 		org->dataMap.Append(temp_name, val);
 		org->dataMap.setOutputBehavior(temp_name, DataMap::AVE);

--- a/World/TestWorld/TestWorld.cpp
+++ b/World/TestWorld/TestWorld.cpp
@@ -28,9 +28,7 @@ TestWorld::TestWorld(shared_ptr<ParametersTable> _PT) :
 	// columns to be added to ave file
 	popFileColumns.clear();
 	popFileColumns.push_back("score");
-	popFileColumns.push_back("score_VAR");
-	popFileColumns.push_back("optimizeValue");
-	popFileColumns.push_back("optimizeValue_VAR");
+	popFileColumns.push_back("score_VAR"); // specifies to also record the variance (performed automatically because _VAR)
 }
 
 // score is number of outputs set to 1 (i.e. output > 0) squared

--- a/buildOptions.txt
+++ b/buildOptions.txt
@@ -1,12 +1,12 @@
 % World
-  * Weed
+  + Weed
   + MorrisTest
   + Berry
   + BerryPlus
   + IPD
   + NumeralClassifier
   + SOF
-  + Test
+  * Test
   + RPP
 
 % Genome

--- a/buildOptions.txt
+++ b/buildOptions.txt
@@ -14,8 +14,8 @@
   * Circular
   
 % Brain
-  + Markov
-  * CGP
+  * Markov
+  + CGP
   + LSTM
   + ConstantValues
   + GeneticPrograming


### PR DESCRIPTION
Fixes a number of things so MABE compiles OOB:

commits:
- fixed CGPBrain::makeCopy needs to be written, by making it non-default
- tidied up unintentional code for optimizeValue left in TestWorld
- fixed IPDWorld push keys to adhere to '-' instead of '_' unless for...
- fixed NumeralClassifierWorld push keys '_' to '-' to avoid '_VAR' etc
- modified buidOptions to have Test as default World
